### PR TITLE
Set the file encoding to UTF8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@
 FROM 1science/java:oracle-jre-8
 MAINTAINER 1science Devops Team <devops@1science.org>
 
-ENV SBT_VERSION 0.13.11
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+ENV SBT_VERSION 0.13.15
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${PATH}:${SBT_HOME}/bin
 


### PR DESCRIPTION
To prevent issues like https://github.com/sbt/sbt-assembly/issues/259
Previously file.encoding was reported as "ANSI_X3.4-1968".

Also update sbt launcher version.